### PR TITLE
fixed k8s.io package parse error

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -18,7 +18,7 @@ import (
 )
 
 var urlRegex = regexp.MustCompile(`([A-Za-z0-9_.-]+((/[A-Za-z0-9_.-]+)+?)?)/?(/info/refs|/git-upload-pack|\?go-get=1)`)
-var repoRegex = regexp.MustCompile(`content="(.+?) git (.+)?"`)
+var repoRegex = regexp.MustCompile(`content="(.+?)\s*git\s*(.+)?"`)
 
 // NewServer create a Server instance
 // The gopath should be a valid folder and will store git repositories later


### PR DESCRIPTION
when use package from k8s.io,  gotit got  `parse meta tag error`, for example:

https://k8s.io/kubernetes?go-get=1

![image](https://user-images.githubusercontent.com/5196641/47363415-55dca080-d709-11e8-9d70-2833c762f5bf.png)
